### PR TITLE
Downgrading required CMake VERSION to 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(Miraclecast)
 set(CMAKE_C_FLAGS "-std=c99") 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.0)
 
 add_subdirectory(src)
 add_subdirectory(res)


### PR DESCRIPTION
Not tested, but the latest development version of Ubuntu (Vivid) has at least 3.0.2.

So, it will make builds work on launchpad:
* https://launchpadlibrarian.net/200818197/buildlog_ubuntu-vivid-amd64.miraclecast_0.0.0~rev120~pkg2~ubuntu15.04.1_BUILDING.txt.gz
* https://code.launchpad.net/~thopiekar/+recipe/miraclecast-daily
```
dpkg-source: warning: extracting unsigned source package (miraclecast_0.0.0~rev120~pkg2~ubuntu15.04.1.dsc)
dpkg-source: info: extracting miraclecast in miraclecast-0.0.0~rev120~pkg2~ubuntu15.04.1
dpkg-source: info: unpacking miraclecast_0.0.0~rev120~pkg2~ubuntu15.04.1.tar.gz
dpkg-buildpackage: source package miraclecast
dpkg-buildpackage: source version 0.0.0~rev120~pkg2~ubuntu15.04.1
dpkg-buildpackage: source distribution vivid
 dpkg-source --before-build miraclecast-0.0.0~rev120~pkg2~ubuntu15.04.1
dpkg-buildpackage: host architecture amd64
 /usr/bin/fakeroot debian/rules clean
dh clean 
   dh_testdir
   dh_auto_clean
   dh_clean
 debian/rules build
dh build 
   dh_testdir
   dh_auto_configure
-- The C compiler identification is GNU 4.9.2
-- The CXX compiler identification is GNU 4.9.2
-- Check for working C compiler: /usr/bin/x86_64-linux-gnu-gcc
-- Check for working C compiler: /usr/bin/x86_64-linux-gnu-gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/x86_64-linux-gnu-g++
-- Check for working CXX compiler: /usr/bin/x86_64-linux-gnu-g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
CMake Error at CMakeLists.txt:3 (cmake_minimum_required):
  CMake 3.1 or higher is required.  You are running version 3.0.2


-- Configuring incomplete, errors occurred!
See also "/build/buildd/miraclecast-0.0.0~rev120~pkg2~ubuntu15.04.1/obj-x86_64-linux-gnu/CMakeFiles/CMakeOutput.log".
dh_auto_configure: cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=None returned exit code 1
debian/rules:22: recipe for target 'build' failed
make: *** [build] Error 2
dpkg-buildpackage: error: debian/rules build gave error exit status 2
```