### PR TITLE
add or correct shebang on res scripts

### DIFF
--- a/res/normal-wifi.sh
+++ b/res/normal-wifi.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ./kill-wpa.sh
 
 . miracle-utils.sh

--- a/res/test-wifi-capabilities.sh
+++ b/res/test-wifi-capabilities.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 . miracle-utils.sh
 


### PR DESCRIPTION
Hello,

This is a small correction of normal-wifi.sh and test-wifi-capabilities.sh regarding shebang as it does not work as is in other shell (zsh for instance).

Regards,
JoKoT3