### PR TITLE
Some minor tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ OPTION(BUILD_ENABLE_DEBUG "Enable Debug" ON )
 OPTION(RELY_UDEV "Rely in udev tag to select device" OFF )
 OPTION(BUILD_TESTS "Enable TEST" ON )
 
+if(BUILD_ENABLE_DEBUG)
+    add_definitions(-DBUILD_ENABLE_DEBUG)
+endif()
+
 find_package(PkgConfig)
 pkg_check_modules (GLIB2 REQUIRED glib-2.0)
 pkg_check_modules (UDEV REQUIRED libudev)

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Steps to use it as peer:
 
  4. Locate them using scanning
 
-        > psp-scan
+        > p2p-scan
 
  5. Apart from list, or show info with peer &lt;mac&gt; there's nothing useful here by now. For a Q&D see [Using as peer](https://github.com/albfan/miraclecast/issues/4)
 

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -1,8 +1,6 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#cmakedefine BUILD_ENABLE_DEBUG
-
 #cmakedefine BUILD_BINDIR "@BUILD_BINDIR@"
 
 #cmakedefine PACKAGE_STRING "@PACKAGE_STRING@"


### PR DESCRIPTION
* Enable debugging and tracing message by define BUILD_ENABLE_DEBUG through add_definitions() because shl_log.h does not include config.h
* Add BUILD_WPA_BINDIR to specify default path to search wpa_supplicant per distro