### PR TITLE
CMake: correctly set file permissions

### DIFF
--- a/res/CMakeLists.txt
+++ b/res/CMakeLists.txt
@@ -1,7 +1,11 @@
 
 ########### install files ###############
 
-install(FILES miracle-gst gstplayer uibc-viewer DESTINATION bin)
+install(
+    FILES miracle-gst gstplayer uibc-viewer
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+    DESTINATION bin
+    )
 
 
 


### PR DESCRIPTION
When building using CMake, the display would not appear
because the files did not have execute permissions.