### PR TITLE
CMake: use PROGRAMS during install

### DIFF
--- a/res/CMakeLists.txt
+++ b/res/CMakeLists.txt
@@ -2,8 +2,7 @@
 ########### install files ###############
 
 install(
-    FILES miracle-gst gstplayer uibc-viewer
-    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+    PROGRAMS miracle-gst gstplayer uibc-viewer
     DESTINATION bin
     )
 


### PR DESCRIPTION
During install, PROGRAMS (instead of FILES) will set
execute permissions for all targets.