### PR TITLE
add option --use-dev to miracle-wifid to workaround the 'no ifname' issue

### DIFF
--- a/src/shared/wpas.c
+++ b/src/shared/wpas.c
@@ -742,6 +742,7 @@ static int wpas__parse_message(struct wpas *w,
 	const char *ifname = NULL;
 	unsigned int level;
 	char *pos;
+	char *orig_raw = raw;
 	int r, num;
 	bool is_event = false;
 
@@ -751,7 +752,7 @@ static int wpas__parse_message(struct wpas *w,
 		ifname = pos;
 		pos = strchrnul(pos, ' ');
 		if (*pos)
-			*pos++ = 0;
+			pos++;
 
 		len -= pos - raw;
 		raw = pos;
@@ -811,15 +812,12 @@ static int wpas__parse_message(struct wpas *w,
 
 	m->sealed = true;
 	m->rawlen = len;
-	m->raw = malloc(len + 1);
+	m->raw = strdup(orig_raw);
 	if (!m->raw)
 		return -ENOMEM;
 
-	/* copy with 0-terminator */
-	memcpy(m->raw, raw, len + 1);
-
 	if (ifname) {
-		m->ifname = strdup(ifname);
+		m->ifname = strndup(ifname, strchrnul(ifname, ' ') - ifname);
 		if (!m->ifname)
 			return -ENOMEM;
 	}

--- a/src/wifi/wifid-link.c
+++ b/src/wifi/wifid-link.c
@@ -132,6 +132,16 @@ void link_free(struct link *l)
 	free(l);
 }
 
+void link_use_dev(struct link *l)
+{
+    l->use_dev = true;
+}
+
+bool link_is_using_dev(struct link *l)
+{
+    return l->use_dev;
+}
+
 void link_set_managed(struct link *l, bool set)
 {
 	int r;

--- a/src/wifi/wifid-supplicant.c
+++ b/src/wifi/wifid-supplicant.c
@@ -2147,6 +2147,9 @@ static int supplicant_global_fn(struct wpas *w,
 	}
 
 	/* ignore events on the global-iface, we only listen on dev-iface */
+	if(wpas_message_get_ifname(m)) {
+        supplicant_event(s, m);
+    }
 
 	return 0;
 

--- a/src/wifi/wifid-supplicant.c
+++ b/src/wifi/wifid-supplicant.c
@@ -2147,7 +2147,7 @@ static int supplicant_global_fn(struct wpas *w,
 	}
 
 	/* ignore events on the global-iface, we only listen on dev-iface */
-	if(wpas_message_get_ifname(m)) {
+	if(link_is_using_dev(s->l) && wpas_message_get_ifname(m)) {
         supplicant_event(s, m);
     }
 

--- a/src/wifi/wifid.c
+++ b/src/wifi/wifid.c
@@ -42,6 +42,7 @@
 
 const char *interface_name = NULL;
 unsigned int arg_wpa_loglevel = LOG_NOTICE;
+bool use_dev = false;
 
 /*
  * Manager Handling
@@ -101,6 +102,9 @@ static void manager_add_udev_link(struct manager *m,
 		return;
 
 	link_set_friendly_name(l, m->friendly_name);
+
+    if(use_dev)
+        link_use_dev(l);
 
 #ifdef RELY_UDEV
 	if (udev_device_has_tag(d, "miracle")) {
@@ -457,6 +461,7 @@ static int help(void)
 	       "  -i --interface           Choose the interface to use\n"
 	       "\n"
 	       "     --wpa-loglevel <lvl   wpa_supplicant log-level\n"
+	       "     --use-dev             enable workaround for 'no ifname' issue\n"
 	       , program_invocation_short_name);
 	/*
 	 * 80-char barrier:
@@ -474,6 +479,8 @@ static int parse_argv(int argc, char *argv[])
 		ARG_LOG_TIME,
 
 		ARG_WPA_LOGLEVEL,
+
+		ARG_USE_DEV,
 	};
 	static const struct option options[] = {
 		{ "help",	no_argument,		NULL,	'h' },
@@ -483,6 +490,7 @@ static int parse_argv(int argc, char *argv[])
 
 		{ "wpa-loglevel",	required_argument,	NULL,	ARG_WPA_LOGLEVEL },
 		{ "interface",	required_argument,	NULL,	'i' },
+		{ "use-dev",	no_argument,	NULL,	ARG_USE_DEV },
 		{}
 	};
 	int c;
@@ -502,6 +510,9 @@ static int parse_argv(int argc, char *argv[])
 			break;
 		case ARG_LOG_TIME:
 			log_init_time();
+			break;
+		case ARG_USE_DEV:
+			use_dev = true;
 			break;
 
 		case ARG_WPA_LOGLEVEL:

--- a/src/wifi/wifid.h
+++ b/src/wifi/wifid.h
@@ -135,6 +135,7 @@ struct link {
 
 	bool managed : 1;
 	bool public : 1;
+	bool use_dev : 1;
 };
 
 #define link_from_htable(_l) \
@@ -152,6 +153,10 @@ int link_new(struct manager *m,
 	     const char *ifname,
 	     struct link **out);
 void link_free(struct link *l);
+
+/* workaround for the 'no ifname' issue */
+void link_use_dev(struct link *l);
+bool link_is_using_dev(struct link *l);
 
 void link_set_managed(struct link *l, bool set);
 int link_renamed(struct link *l, const char *ifname);


### PR DESCRIPTION
On my laptop, the wpa_message starts with IFNAME= are dispatched to supplicant_global_fn(), the wpa_message without IFNAME= are dispatched to supplicant_dev_fn(), which causes supplicant_event_ap_sta_connected() prints 'no ifname in AP-STA-CONNECTED' then return without calling supplicant_peer_set_group().

This patch tries to forward wpa_message starts with IFNAME= to supplicant_dev_fn() so peer can be bound and finish grouping.

I think this may not be the best solution for solving the root cause, but it works fine in my case.