### PR TITLE
fix DHCP_SERVER_ID by change its byte order again

### DIFF
--- a/src/dhcp/server.c
+++ b/src/dhcp/server.c
@@ -456,7 +456,7 @@ static void init_packet(GDHCPServer *dhcp_server, struct dhcp_packet *packet,
 	packet->gateway_nip = client_packet->gateway_nip;
 	packet->ciaddr = client_packet->ciaddr;
 	dhcp_add_option_uint32(packet, DHCP_SERVER_ID,
-						dhcp_server->server_nip);
+						get_be32(&dhcp_server->server_nip));
 }
 
 static void add_option(gpointer key, gpointer value, gpointer user_data)
@@ -675,7 +675,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 
 	server_id_option = dhcp_get_option(&packet, DHCP_SERVER_ID);
 	if (server_id_option) {
-		uint32_t server_nid = get_be32(server_id_option);
+		uint32_t server_nid = get_unaligned((uint32_t *) server_id_option);
 
 		if (server_nid != dhcp_server->server_nip)
 			return TRUE;


### PR DESCRIPTION
This patch fixes byte order of DHCP SERVER_ID option.

Since sink tries to find source by SERVER_ID option, if the SERVER_ID were wrong, source won't be able to get connection request from sink, eg
```
192.168.50.100.49080 > 1.50.168.192.7236: Flags [S], cksum 0x2508 (correct), seq 4028751266, win 14600, options [mss 1460,sackOK,TS val 4294943537 ecr 0,nop,wscale 5], length 0
```

The log above shows a sink is trying to connect to source (`192.168.50.100` is the sink. `192.168.50.1` is the source). But since DHCP sent SERVER_ID option in wrong byte order, the actual IP address the sink connects to is `1.50.168.192`.

The issue is caused by line 458 in `src/dhcp/server.c`
```
dhcp_add_option_uint32(packet, DHCP_SERVER_ID, &dhcp_server->server_nip);
```

and  line 285 in `src/dhcp/common.c`
```
    put_be32(data, option + OPT_DATA);
```

The `dhcp_server->server_nip` is in network byte order, the `put_be32()` will change its byte order again - the result will be an IP address in little endian (big => little). So the fix is to change the byte order of `dhcp_server->server_nip` before calling `dhcp_add_option_uint32()` (big => little => big).

Since now the SERVER_ID option is in wright byte order, the line 678 in `src/dhcp/server.c` no longer need to change the byte order of SERVER_ID option before compare it to `dhcp_server->server_nip` (both in big endian), so replace `get_be32()` with `get_unaligned()`.