### PR TITLE
Make miracle-wifid conexists with other network tools

### DIFF
--- a/src/ctl/ctl-wifi.c
+++ b/src/ctl/ctl-wifi.c
@@ -414,6 +414,8 @@ static int ctl_link_parse_properties(struct ctl_link *l,
 	bool p2p_scanning_set = false;
 	char *tmp;
 	int p2p_scanning, r;
+	bool managed_set = false;
+	int managed;
 
 	if (!l || !m)
 		return cli_EINVAL();
@@ -444,6 +446,13 @@ static int ctl_link_parse_properties(struct ctl_link *l,
 						&friendly_name);
 			if (r < 0)
 				return cli_log_parser(r);
+		} else if (!strcmp(t, "Managed")) {
+			r = bus_message_read_basic_variant(m, "b",
+						&managed);
+			if (r < 0)
+				return cli_log_parser(r);
+
+			managed_set = true;
 		} else if (!strcmp(t, "P2PScanning")) {
 			r = bus_message_read_basic_variant(m, "b",
 						&p2p_scanning);
@@ -493,6 +502,9 @@ static int ctl_link_parse_properties(struct ctl_link *l,
 			cli_vENOMEM();
 		}
 	}
+
+	if (managed_set)
+		l->managed = managed;
 
 	if (p2p_scanning_set)
 		l->p2p_scanning = p2p_scanning;
@@ -616,6 +628,63 @@ int ctl_link_set_wfd_subelements(struct ctl_link *l, const char *val)
 			  l->label, val, bus_error_message(&err, r));
 		return r;
 	}
+
+	return 0;
+}
+
+int ctl_link_set_managed(struct ctl_link *l, bool val)
+{
+	_sd_bus_message_unref_ sd_bus_message *m = NULL;
+	_sd_bus_error_free_ sd_bus_error err = SD_BUS_ERROR_NULL;
+	_shl_free_ char *node = NULL;
+	int r;
+
+	if (!l)
+		return cli_EINVAL();
+	if (l->managed == val)
+		return 0;
+
+	r = sd_bus_path_encode("/org/freedesktop/miracle/wifi/link",
+			       l->label,
+			       &node);
+	if (r < 0)
+		return cli_ERR(r);
+
+	r = sd_bus_message_new_method_call(l->w->bus,
+					   &m,
+					   "org.freedesktop.miracle.wifi",
+					   node,
+					   "org.freedesktop.DBus.Properties",
+					   "Set");
+	if (r < 0)
+		return cli_log_create(r);
+
+	r = sd_bus_message_append(m, "ss",
+				  "org.freedesktop.miracle.wifi.Link",
+				  "Managed");
+	if (r < 0)
+		return cli_log_create(r);
+
+	r = sd_bus_message_open_container(m, 'v', "b");
+	if (r < 0)
+		return cli_log_create(r);
+
+	r = sd_bus_message_append(m, "b", val);
+	if (r < 0)
+		return cli_log_create(r);
+
+	r = sd_bus_message_close_container(m);
+	if (r < 0)
+		return cli_log_create(r);
+
+	r = sd_bus_call(l->w->bus, m, 0, &err, NULL);
+	if (r < 0) {
+		cli_error("cannot change managed state on link %s to %d: %s",
+			  l->label, val, bus_error_message(&err, r));
+		return r;
+	}
+
+	l->managed = val;
 
 	return 0;
 }

--- a/src/ctl/ctl.h
+++ b/src/ctl/ctl.h
@@ -71,6 +71,7 @@ struct ctl_link {
 	unsigned int ifindex;
 	char *ifname;
 	char *friendly_name;
+	bool managed;
 	char *wfd_subelements;
 	bool p2p_scanning;
 };
@@ -78,6 +79,7 @@ struct ctl_link {
 #define link_from_dlist(_l) shl_dlist_entry((_l), struct ctl_link, list);
 
 int ctl_link_set_friendly_name(struct ctl_link *l, const char *name);
+int ctl_link_set_managed(struct ctl_link *l, bool val);
 int ctl_link_set_wfd_subelements(struct ctl_link *l, const char *val);
 int ctl_link_set_p2p_scanning(struct ctl_link *l, bool val);
 

--- a/src/ctl/wifictl.c
+++ b/src/ctl/wifictl.c
@@ -51,19 +51,20 @@ static int cmd_list(char **args, unsigned int n)
 
 	/* list links */
 
-	cli_printf("%6s %-24s %-30s\n",
-		   "LINK", "INTERFACE", "FRIENDLY-NAME");
+	cli_printf("%6s %-24s %-30s %-10s\n",
+		   "LINK", "INTERFACE", "FRIENDLY-NAME", "MANAGED");
 
 	shl_dlist_for_each(i, &wifi->links) {
 		l = link_from_dlist(i);
 		++link_cnt;
 
-		cli_printf("%6s %-24s %-30s\n",
+		cli_printf("%6s %-24s %-30s %-10s\n",
 			   l->label,
 			   shl_isempty(l->ifname) ?
 			       "<unknown>" : l->ifname,
 			   shl_isempty(l->friendly_name) ?
-			       "<unknown>" : l->friendly_name);
+			       "<unknown>" : l->friendly_name,
+			   l->managed ? "yes": "no");
 	}
 
 	cli_printf("\n");
@@ -156,6 +157,7 @@ static int cmd_show(char **args, unsigned int n)
 		cli_printf("P2PScanning=%d\n", l->p2p_scanning);
 		if (l->wfd_subelements && *l->wfd_subelements)
 			cli_printf("WfdSubelements=%s\n", l->wfd_subelements);
+		cli_printf("Managed=%d\n", l->managed);
 	} else if (p) {
 		cli_printf("Peer=%s\n", p->label);
 		if (p->p2p_mac && *p->p2p_mac)
@@ -211,7 +213,51 @@ static int cmd_set_friendly_name(char **args, unsigned int n)
 		return 0;
 	}
 
+	if (!l->managed) {
+		cli_printf("link %s not managed\n", l->label);
+		return 0;
+	}
+
 	return ctl_link_set_friendly_name(l, name);
+}
+
+/*
+ * cmd: set-managed
+ */
+
+static int cmd_set_managed(char **args, unsigned int n)
+{
+	struct ctl_link *l = NULL;
+	const char *value;
+	bool managed = true;
+
+	if (n < 1) {
+		cli_printf("To what?\n");
+		return 0;
+	}
+
+	if (n > 1) {
+		l = ctl_wifi_search_link(wifi, args[0]);
+		if (!l) {
+			cli_error("unknown link %s", args[0]);
+			return 0;
+		}
+
+		value = args[1];
+	} else {
+		value = args[0];
+	}
+
+	l = l ? : selected_link;
+	if (!l) {
+		cli_error("no link selected");
+		return 0;
+	}
+
+	if (!strcmp(value, "no")) {
+		managed = false;
+	}
+	return ctl_link_set_managed(l, managed);
 }
 
 /*
@@ -239,6 +285,11 @@ static int cmd_p2p_scan(char **args, unsigned int n)
 	l = l ? : selected_link;
 	if (!l) {
 		cli_error("no link selected");
+		return 0;
+	}
+
+	if (!l->managed) {
+		cli_printf("link %s not managed\n", l->label);
 		return 0;
 	}
 
@@ -289,6 +340,11 @@ static int cmd_connect(char **args, unsigned int n)
 		pin = "";
 	}
 
+	if (!p->l->managed) {
+		cli_printf("link %s not managed\n", p->l->label);
+		return 0;
+	}
+
 	return ctl_peer_connect(p, prov, pin);
 }
 
@@ -308,6 +364,11 @@ static int cmd_disconnect(char **args, unsigned int n)
 	p = ctl_wifi_search_peer(wifi, args[0]);
 	if (!p) {
 		cli_error("unknown peer %s", args[0]);
+		return 0;
+	}
+
+	if (!p->l->managed) {
+		cli_printf("link %s not managed\n", p->l->label);
 		return 0;
 	}
 
@@ -333,6 +394,7 @@ static const struct cli_cmd cli_cmds[] = {
 	{ "select",		"[link]",				CLI_Y,	CLI_LESS,	1,	cmd_select,		"Select default link" },
 	{ "show",		"[link|peer]",				CLI_M,	CLI_LESS,	1,	cmd_show,		"Show detailed object information" },
 	{ "set-friendly-name",	"[link] <name>",			CLI_M,	CLI_LESS,	2,	cmd_set_friendly_name,	"Set friendly name of an object" },
+	{ "set-managed",	"[link] <yes|no>",	CLI_M,	CLI_LESS,	2,	cmd_set_managed,	"Manage or unmnage a link" },
 	{ "p2p-scan",		"[link] [stop]",			CLI_Y,	CLI_LESS,	2,	cmd_p2p_scan,		"Control neighborhood P2P scanning" },
 	{ "connect",		"<peer> [provision] [pin]",		CLI_M,	CLI_LESS,	3,	cmd_connect,		"Connect to peer" },
 	{ "disconnect",		"<peer>",				CLI_M,	CLI_EQUAL,	1,	cmd_disconnect,		"Disconnect from peer" },

--- a/src/shared/shl_log.h
+++ b/src/shared/shl_log.h
@@ -226,4 +226,9 @@ extern const char *LOG_SUBSYSTEM;
 #define log_vERR(_r) \
 	((void)log_ERR(_r))
 
+#define log_EUNMANAGED() \
+	(log_error("interface unmanaged"), -EFAULT)
+#define log_vEUNMANAGED() \
+	((void)log_EUNMANAGED())
+
 #endif /* SHL_LOG_H */

--- a/src/wifi/wifid-dbus.c
+++ b/src/wifi/wifid-dbus.c
@@ -570,6 +570,42 @@ static int link_dbus_set_friendly_name(sd_bus *bus,
 	return link_set_friendly_name(l, name);
 }
 
+static int link_dbus_get_managed(sd_bus *bus,
+				      const char *path,
+				      const char *interface,
+				      const char *property,
+				      sd_bus_message *reply,
+				      void *data,
+				      sd_bus_error *err)
+{
+	struct link *l = data;
+	int r;
+
+	r = sd_bus_message_append(reply, "b", link_get_managed(l));
+	if (r < 0)
+		return r;
+
+	return 1;
+}
+
+static int link_dbus_set_managed(sd_bus *bus,
+				      const char *path,
+				      const char *interface,
+				      const char *property,
+				      sd_bus_message *value,
+				      void *data,
+				      sd_bus_error *err)
+{
+	struct link *l = data;
+	int val, r;
+
+	r = sd_bus_message_read(value, "b", &val);
+	if (r < 0)
+		return r;
+
+	return link_set_managed(l, val);
+}
+
 static int link_dbus_get_p2p_scanning(sd_bus *bus,
 				      const char *path,
 				      const char *interface,
@@ -659,6 +695,12 @@ static const sd_bus_vtable link_dbus_vtable[] = {
 				 "s",
 				 link_dbus_get_friendly_name,
 				 link_dbus_set_friendly_name,
+				 0,
+				 SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("Managed",
+				 "b",
+				 link_dbus_get_managed,
+				 link_dbus_set_managed,
 				 0,
 				 SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_WRITABLE_PROPERTY("P2PScanning",

--- a/src/wifi/wifid-link.c
+++ b/src/wifi/wifid-link.c
@@ -100,6 +100,8 @@ int link_new(struct manager *m,
 	if (out)
 		*out = l;
 
+	l->public = true;
+	link_dbus_added(l);
 	return 0;
 
 error:
@@ -115,6 +117,9 @@ void link_free(struct link *l)
 	log_debug("free link: %s (%u)", l->ifname, l->ifindex);
 
 	link_set_managed(l, false);
+
+	link_dbus_removed(l);
+	l->public = false;
 
 	if (shl_htable_remove_uint(&l->m->links, l->ifindex, NULL)) {
 		log_info("remove link: %s", l->ifname);
@@ -142,14 +147,19 @@ bool link_is_using_dev(struct link *l)
     return l->use_dev;
 }
 
-void link_set_managed(struct link *l, bool set)
+bool link_get_managed(struct link *l)
+{
+	return l->managed;
+}
+
+int link_set_managed(struct link *l, bool set)
 {
 	int r;
 
 	if (!l)
-		return log_vEINVAL();
+		return log_EINVAL();
 	if (l->managed == set)
-		return;
+		return 0;
 
 	if (set) {
 		log_info("manage link %s", l->ifname);
@@ -157,7 +167,7 @@ void link_set_managed(struct link *l, bool set)
 		r = supplicant_start(l->s);
 		if (r < 0) {
 			log_error("cannot start supplicant on %s", l->ifname);
-			return;
+			return -EFAULT;
 		}
 	} else {
 		log_info("link %s no longer managed", l->ifname);
@@ -165,6 +175,7 @@ void link_set_managed(struct link *l, bool set)
 	}
 
 	l->managed = set;
+	return 0;
 }
 
 int link_renamed(struct link *l, const char *ifname)
@@ -198,6 +209,9 @@ int link_set_friendly_name(struct link *l, const char *name)
 
 	if (!l || !name || !*name)
 		return log_EINVAL();
+
+	if (!l->managed)
+		return log_EUNMANAGED();
 
 	t = strdup(name);
 	if (!t)
@@ -234,6 +248,9 @@ int link_set_wfd_subelements(struct link *l, const char *val)
 	if (!l || !val)
 		return log_EINVAL();
 
+	if (!l->managed)
+		return log_EUNMANAGED();
+
 	t = strdup(val);
 	if (!t)
 		return log_ENOMEM();
@@ -266,6 +283,9 @@ int link_set_p2p_scanning(struct link *l, bool set)
 	if (!l)
 		return log_EINVAL();
 
+	if (!l->managed)
+		return log_EUNMANAGED();
+
 	if (set) {
 		return supplicant_p2p_start_scan(l->s);
 	} else {
@@ -276,7 +296,16 @@ int link_set_p2p_scanning(struct link *l, bool set)
 
 bool link_get_p2p_scanning(struct link *l)
 {
-	return l && supplicant_p2p_scanning(l->s);
+	if (!l) {
+		log_vEINVAL();
+		return false;
+	}
+
+	if (!l->managed) {
+		return false;
+	}
+
+	return supplicant_p2p_scanning(l->s);
 }
 
 void link_supplicant_started(struct link *l)
@@ -284,9 +313,8 @@ void link_supplicant_started(struct link *l)
 	if (!l || l->public)
 		return;
 
-	log_debug("link %s started", l->ifname);
-	l->public = true;
-	link_dbus_added(l);
+	link_set_friendly_name(l, l->m->friendly_name);
+	log_info("link %s managed", l->ifname);
 }
 
 void link_supplicant_stopped(struct link *l)
@@ -294,9 +322,7 @@ void link_supplicant_stopped(struct link *l)
 	if (!l || !l->public)
 		return;
 
-	log_debug("link %s stopped", l->ifname);
-	link_dbus_removed(l);
-	l->public = false;
+	log_info("link %s unmanaged", l->ifname);
 }
 
 void link_supplicant_p2p_scan_changed(struct link *l, bool new_value)

--- a/src/wifi/wifid.c
+++ b/src/wifi/wifid.c
@@ -43,6 +43,7 @@
 const char *interface_name = NULL;
 unsigned int arg_wpa_loglevel = LOG_NOTICE;
 bool use_dev = false;
+bool lazy_managed = false;
 
 /*
  * Manager Handling
@@ -101,15 +102,13 @@ static void manager_add_udev_link(struct manager *m,
 	if (r < 0)
 		return;
 
-	link_set_friendly_name(l, m->friendly_name);
-
     if(use_dev)
         link_use_dev(l);
 
 #ifdef RELY_UDEV
-	if (udev_device_has_tag(d, "miracle")) {
+	if (udev_device_has_tag(d, "miracle") && !lazy_managed) {
 #else
-	if (!interface_name || !strcmp(interface_name, ifname)) {
+	if ((!interface_name || !strcmp(interface_name, ifname)) && !lazy_managed) {
 #endif
 		link_set_managed(l, true);
 	} else {
@@ -150,12 +149,12 @@ static int manager_udev_fn(sd_event_source *source,
 		}
 
 #ifdef RELY_UDEV
-		if (udev_device_has_tag(d, "miracle"))
+		if (udev_device_has_tag(d, "miracle") && !lazy_managed)
 			link_set_managed(l, true);
 		else
 			link_set_managed(l, false);
 #else
-		if (!interface_name || !strcmp(interface_name, ifname)) {
+		if ((!interface_name || !strcmp(interface_name, ifname)) && !lazy_managed) {
 			link_set_managed(l, true);
 		} else {
 			log_debug("ignored device: %s", ifname);
@@ -462,6 +461,7 @@ static int help(void)
 	       "\n"
 	       "     --wpa-loglevel <lvl   wpa_supplicant log-level\n"
 	       "     --use-dev             enable workaround for 'no ifname' issue\n"
+	       "     --lazy-managed        manage interface only when user decide to do\n"
 	       , program_invocation_short_name);
 	/*
 	 * 80-char barrier:
@@ -481,6 +481,7 @@ static int parse_argv(int argc, char *argv[])
 		ARG_WPA_LOGLEVEL,
 
 		ARG_USE_DEV,
+		ARG_LAZY_MANAGED,
 	};
 	static const struct option options[] = {
 		{ "help",	no_argument,		NULL,	'h' },
@@ -491,6 +492,7 @@ static int parse_argv(int argc, char *argv[])
 		{ "wpa-loglevel",	required_argument,	NULL,	ARG_WPA_LOGLEVEL },
 		{ "interface",	required_argument,	NULL,	'i' },
 		{ "use-dev",	no_argument,	NULL,	ARG_USE_DEV },
+		{ "lazy-managed",	no_argument,	NULL,	ARG_LAZY_MANAGED },
 		{}
 	};
 	int c;
@@ -513,6 +515,9 @@ static int parse_argv(int argc, char *argv[])
 			break;
 		case ARG_USE_DEV:
 			use_dev = true;
+			break;
+		case ARG_LAZY_MANAGED:
+			lazy_managed = true;
 			break;
 
 		case ARG_WPA_LOGLEVEL:

--- a/src/wifi/wifid.h
+++ b/src/wifi/wifid.h
@@ -158,7 +158,8 @@ void link_free(struct link *l);
 void link_use_dev(struct link *l);
 bool link_is_using_dev(struct link *l);
 
-void link_set_managed(struct link *l, bool set);
+int link_set_managed(struct link *l, bool set);
+bool link_get_managed(struct link *l);
 int link_renamed(struct link *l, const char *ifname);
 
 int link_set_friendly_name(struct link *l, const char *name);


### PR DESCRIPTION
The new option --lazy-managed will let miracle-wifid don't managed the
links automatically. Instead, the link will be managed only when the new
DBus property Managed was set to true. So this will be possible that
miracle-wifid could be conexists with other network tools like
networkmanager.

For example, unmange the device in networkmanager with the DBus property
org.freedesktop.NetworkManager.Device.Managed and manage it in
miracle-wifid with org.freedesktop.miracle.wifi.Link.Managed, then all
could works and don't need to kill each other.

Besides, there is new command named make-managed in miracle-wifictl and
miracle-sinkctla. <del>And the command run/select will ensure the link
managed to keep the user commands same as before.</del>

BTW: I just follow networkmanager's DBus style and add a property `Managed` in miracle link node, maybe it not fits current interfaces and I saw there is an empty class named `org.freedesktop.miracle.wifi.Manager` looks is the right place to implement such functions. Anyway, I think let user to manage links manually is necessary, wish this PR helps and thanks for the great work for miraclecast, it's really cool :)
