### PR TITLE
Allow to extend protocol

### DIFF
--- a/res/sinkctl.protocol-extension.example
+++ b/res/sinkctl.protocol-extension.example
@@ -1,0 +1,18 @@
+#Example of extra parameters to extend sink request
+
+[sinkctl]
+extends.wfd_video_formats=40 00 01 10 0001bdeb 051557ff 00000fff 10 0000 001f 11 0780 0438, 02 10 0001bdeb 155557ff 00000fff 10 0000 001f 11 0780 0438
+extends.wfd_audio_codecs=LPCM 00000003 00, AAC 0000000f 00, AC3 00000007 00
+extends.wfd_display_edid=0001 00ffffffffffff0051f38f50010000000e100104a51d10ff2f0000a057499b2610484f000000010101010101010101010101010101011a36809c70381f403020350025a510000018000000fc00496e7465726e616c204c43440a000000fd003c3c9a9a0e00000000000000000000000000000000000000000000000000000030
+extends.wfd_connector_type=05
+extends.microsoft_cursor=none
+extends.microsoft_rtcp_capability=none
+extends.wfd_idr_request_capability=1
+extends.microsoft_latency_management_capability=none
+extends.microsoft_format_change_capability=none
+extends.microsoft_diagnostics_capability=none
+extends.intel_friendly_name=miraclecast
+extends.intel_sink_manufacturer_name=GNU Linux
+extends.intel_sink_model_name=Arch linux
+extends.intel_sink_device_URL=http://github.com/albfan/miraclecast
+extends.wfd_uibc_capability=input_category_list=GENERIC, HIDC;generic_cap_list=Keyboard;hidc_cap_list=Keyboard/USB, Mouse/USB, MultiTouch/USB, Gesture/USB, RemoteControl/USB;port=none

--- a/src/ctl/ctl-sink.h
+++ b/src/ctl/ctl-sink.h
@@ -32,12 +32,17 @@
 #include <systemd/sd-event.h>
 #include <time.h>
 #include <unistd.h>
+#include <glib.h>
 #include "ctl.h"
 
 #include "rtsp.h"
 #include "shl_macro.h"
 #include "shl_util.h"
 #include "wfd.h"
+
+#define WFD_VIDEO_FORMATS "wfd_video_formats"
+#define WFD_AUDIO_CODECS "wfd_audio_codecs"
+#define WFD_UIBC_CAPABILITY "wfd_uibc_capability"
 
 extern int rstp_port;
 extern bool uibc_option;
@@ -68,6 +73,8 @@ struct ctl_sink {
 
     int hres;
     int vres;
+
+    GHashTable* protocol_extensions;
 };
 
 bool check_rtsp_option(struct rtsp_message *m, char *option);


### PR DESCRIPTION
There're implementations extendind miracast protocol (like microsoft)

This PR allow to define extra parameters in config file:

Example on https://github.com/albfan/miraclecast/pull/136/files#diff-7fd4b081503737d9af689b756a92ca63daf1b5bd1f5cd415ee58db70595a96c4

```
[sinkctl]
extends.<key>=<value>
```

All parameters will be passed to source. wfd_video_format, wfd_audio_codecs, wfd_uibc_capability will be override if present
