### PR TITLE
Some fixes of issues detected by static analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(BUILD_BINDIR "${CMAKE_INSTALL_PREFIX}/bin")
 OPTION(BUILD_ENABLE_DEBUG "Enable Debug" ON )
 OPTION(RELY_UDEV "Rely in udev tag to select device" OFF )
 OPTION(BUILD_TESTS "Enable TEST" ON )
+OPTION(BUILD_ENABLE_CPPCHECK "Enable CPPCheck static analysis" OFF )
 
 if(BUILD_ENABLE_DEBUG)
     add_definitions(-DBUILD_ENABLE_DEBUG)
@@ -29,6 +30,20 @@ pkg_check_modules (UDEV REQUIRED libudev)
 pkg_check_modules (SYSTEMD REQUIRED libsystemd)
 
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/config.h.cmake ${CMAKE_BINARY_DIR}/config.h)
+
+if(BUILD_ENABLE_CPPCHECK)
+    find_program(CMAKE_C_CPPCHECK NAMES cppcheck)
+    if (CMAKE_C_CPPCHECK)
+        list(
+            APPEND CMAKE_C_CPPCHECK
+                "--enable=warning"
+                "--inline-suppr"
+                "--std=c11"
+                "-D__SIZEOF_POINTER__=8"
+        )
+    endif()
+endif()
+
 
 add_subdirectory(src)
 add_subdirectory(res)

--- a/src/dhcp/client.c
+++ b/src/dhcp/client.c
@@ -2785,7 +2785,7 @@ int g_dhcp_client_start(GDHCPClient *dhcp_client, const char *last_address)
 		addr = ntohl(inet_addr(last_address));
 		if (addr == 0xFFFFFFFF) {
 			addr = 0;
-		} else {
+		} else if (dhcp_client->last_address != last_address) {  // Avoiding use-after-free
 			g_free(dhcp_client->last_address);
 			dhcp_client->last_address = g_strdup(last_address);
 		}

--- a/src/shared/rtsp.c
+++ b/src/shared/rtsp.c
@@ -2169,7 +2169,6 @@ static int parser_submit_data(struct rtsp *bus, uint8_t *p)
 				  p,
 				  dec->data_size);
 	if (r < 0) {
-		free(p);
 		return r;
 	}
 

--- a/src/wifi/wifid-supplicant.c
+++ b/src/wifi/wifid-supplicant.c
@@ -1451,7 +1451,6 @@ static void supplicant_event(struct supplicant *s, struct wpas_message *m)
 		    !strcmp(name, "WPS-AP-AVAILABLE-PIN") ||
 		    !strcmp(name, "CTRL-EVENT-EAP-STATUS") ||
 		    !strcmp(name, "CTRL-EVENT-EAP-METHOD") ||
-		    !strcmp(name, "CTRL-EVENT-EAP-STATUS") ||
 		    !strcmp(name, "WPS-CRED-RECEIVED") ||
 		    !strcmp(name, "WPS-AP-AVAILABLE") ||
 		    !strcmp(name, "WPS-REG-SUCCESS") ||

--- a/src/wifi/wifid.c
+++ b/src/wifi/wifid.c
@@ -542,6 +542,7 @@ static int parse_argv(int argc, char *argv[])
 			break;
 		case ARG_CONFIG_METHODS:
 			config_methods = optarg;
+			break;
 		case ARG_LAZY_MANAGED:
 			lazy_managed = true;
 			break;


### PR DESCRIPTION
Disclaimer: I'm not very familiar with the code base, but I have a mildly paranoid habit of turning compiler diagnostics and running some static analysis tools if I'm building some software that requires root privileges. Therefore, I did not aim to fix all the issues detected, but I did fix some:

- Added missing `break` in `switch`. I doubt `--config-methods` flag implies `--lazy-managed`.
- Removed duplicate comparison with `CTRL-EVENT-EAP-STATUS`. It likely was benign unless some other event type was supposed to be there.
- Fixes three potential use-after-free (incl. double free) issues in RTSP and DHCP client code.

I also added the option to run cppcheck during normal CMake build. It seems to produce now some garbage and some complaints about minor memory leaks, so it might be a pain to deal with, but still, it hope it might be helpful in identifying other possible problems.