### PR TITLE
--config-methods arg not handled correctly

### DIFF
--- a/src/wifi/wifid.c
+++ b/src/wifi/wifid.c
@@ -542,6 +542,7 @@ static int parse_argv(int argc, char *argv[])
 			break;
 		case ARG_CONFIG_METHODS:
 			config_methods = optarg;
+			break;
 		case ARG_LAZY_MANAGED:
 			lazy_managed = true;
 			break;


### PR DESCRIPTION
Hi @albfan. I have a very trivial single-line fix here, which you'll surely accept and merge in less than 1 minute :)

I'm trying hard to run a miracast sink and make some android devices connect. I have 3 phones and one tablet, and so far I could only make one phone connect successfully (a Samsung A40 connect and works flawlessly) while others time out. I have a sneaking suspicion the others do not connect because they do not like the ```pbc``` method, so I'm trying to use ```display``` instead. But while doing so I found ```--config-methods``` messes up things even more.  I found a trivial issue while looking through the code: an obviously missing break statement in arg handling code. 

As for the real reason why these device fail, I have no idea yet. I have trace logging enabled but cannot make sense of it as I'm very new to this project. Any pointers for a thread, wiki or other doc on the fail-to-connect subject? Thanks!