### PR TITLE
Support more than 2 devices when testing the capabilities

### DIFF
--- a/res/test-hardware-capabilities.sh
+++ b/res/test-hardware-capabilities.sh
@@ -28,7 +28,7 @@ then
 elif [ 1 = $WIFI_COUNT ]
 then
    WIFI_NAME="$WIFI_NAMES"
-elif [ 2 -ge $WIFI_COUNT ]
+elif [ 2 -le $WIFI_COUNT ]
 then
    echo Choose wireless device:
    PS3="device: "


### PR DESCRIPTION
At the moment, this typo is preventing the test script from working when you have more than 2 devices plugged in. Fixes #449