### PR TITLE
fixed error message

### DIFF
--- a/src/ctl/sinkctl.c
+++ b/src/ctl/sinkctl.c
@@ -174,7 +174,7 @@ static int cmd_show(char **args, unsigned int n)
 		    !(p = ctl_wifi_find_peer(wifi, args[0])) &&
 		    !(l = ctl_wifi_search_link(wifi, args[0])) &&
 		    !(p = ctl_wifi_search_peer(wifi, args[0]))) {
-			cli_error("unknown link or peer %s", args[0]);
+			cli_error("unknown %s", args[0]);
 			return 0;
 		}
 	}


### PR DESCRIPTION
rn the error message says something like this "unknown link or peer link..." or "unknown link or peer peer..." so removing the "link or peer" part. So the error message will be "unknown link..." or "unknown peer..."