### PR TITLE
Fix dependency check to be posix-compliant

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_DEFINE_UNQUOTED([IP_BINARY], [$IP_BINARY], [Path for ip binary])
 # Mandatory dependencies
 #
 
-AS_IF([test "$use_libsystemd" == "yes"],
+AS_IF([test "$use_libsystemd" = "yes"],
   [
      AC_DEFINE([ENABLE_SYSTEMD], [], [Use systemd])
      m4_ifdef([PKG_CHECK_MODULES], [


### PR DESCRIPTION
test with "==" operator works in bash but fails in other shells such as `sh`