### PR TITLE
Fix build with GCC 14.1

### DIFF
--- a/src/ctl/ctl-cli.c
+++ b/src/ctl/ctl-cli.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <strings.h>
 #include <sys/signalfd.h>
+#include <sys/time.h>
 #include <sys/wait.h>
 #include <systemd/sd-bus.h>
 #include "ctl.h"


### PR DESCRIPTION
Compiling with `gcc (GCC) 14.1.1 20240507` raised the following warning:

`error: implicit declaration of function ‘gettimeofday’ [-Wimplicit-function-declaration]`

Adding `#include <sys/time.h>` according to `man gettimeofday` fixes #509.