### PR TITLE
fix gcc15 build error

### DIFF
--- a/src/ctl/ctl-cli.c
+++ b/src/ctl/ctl-cli.c
@@ -87,7 +87,7 @@ void cli_printv(const char *fmt, bool prefix_time, va_list args)
 	}
 }
 
-void cli_printf_time_prefix(const char *fmt, va_list args)
+void cli_printf_time_prefix()
 {
 	long long sec, usec;
 	time_t now;
@@ -306,7 +306,7 @@ void cli_destroy(void)
 		rl_on_new_line();
 		rl_redisplay();
 
-		rl_message("");
+		rl_message("%s", "");
 		rl_callback_handler_remove();
 	}
 

--- a/src/ctl/ctl.h
+++ b/src/ctl/ctl.h
@@ -32,6 +32,8 @@
 #include "shl_dlist.h"
 #include "shl_log.h"
 
+// Force readline to use va_list variants (fixes gcc15 compilation on certain distros)
+#define HAVE_STDARG_H
 /* *sigh* readline doesn't include all their deps, so put them last */
 #include <readline/history.h>
 #include <readline/readline.h>

--- a/src/ctl/sinkctl.c
+++ b/src/ctl/sinkctl.c
@@ -47,7 +47,6 @@
 #include "util.h"
 #include "config.h"
 
-#include <readline/readline.h>
 
 #define HISTORY_FILENAME ".miracle-sink.history"
 

--- a/src/ctl/wifictl.c
+++ b/src/ctl/wifictl.c
@@ -34,7 +34,6 @@
 #include "util.h"
 #include "config.h"
 
-#include <readline/readline.h>
 
 #define HISTORY_FILENAME ".miracle-wifi.history"
 


### PR DESCRIPTION
also a warning in clang:
```
In file included from ../../../src/ctl/ctl-cli.c:33:
../../../src/ctl/ctl.h:139:6: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C23, conflicting with a subsequent definition [-Wdeprecated-non-prototype]
  139 | void cli_printf_time_prefix();
      |      ^
../../../src/ctl/ctl-cli.c:90:6: note: conflicting prototype is here
   90 | void cli_printf_time_prefix(const char *fmt, va_list args)
      |      ^
```
should correctly resolve #532 